### PR TITLE
expirationDateFromHeaders had trouble with Cache-Control + max-age

### DIFF
--- a/SDURLCache.m
+++ b/SDURLCache.m
@@ -168,7 +168,7 @@ static NSDateFormatter* CreateDateFormatter(NSString *format)
             {
                 if (maxAge > 0)
                 {
-                    return [NSDate dateWithTimeIntervalSinceNow:maxAge];
+                    return [[[NSDate alloc] initWithTimeInterval:maxAge sinceDate:now] autorelease];
                 }
                 else
                 {


### PR DESCRIPTION
Changed "expirationDateFromHeaders" beacuse it was miscalculating the expiration date when "Cache-Control" and "max-age" were set. It was adding max-age to the current time, not the time previously established as "now".
