### PR TITLE
Enabled SDURLCache for ios5 and up using a new initializer

### DIFF
--- a/SDURLCache.h
+++ b/SDURLCache.h
@@ -13,7 +13,7 @@
     @private
     NSString *diskCachePath;
     NSMutableDictionary *diskCacheInfo;
-    BOOL diskCacheInfoDirty, ignoreMemoryOnlyStoragePolicy, disabled;
+    BOOL diskCacheInfoDirty, ignoreMemoryOnlyStoragePolicy, disabled, _enableForIOS5AndUp;
     NSUInteger diskCacheUsage;
     NSTimeInterval minCacheInterval;
     NSOperationQueue *ioQueue;
@@ -44,6 +44,16 @@
  * will be located in the application's cache directory and thus won't be synced by iTunes.
  */
 + (NSString *)defaultCachePath;
+
+/* 
+ * yosit: It turns that although ios > 5 has a disk cache it doesn't behave in a predicatable way
+ * the added enableForIOS5AndUp will enable SDURLCache to function like it does on all version of IOS
+ */
+
+- (id)initWithMemoryCapacity:(NSUInteger)memoryCapacity 
+                diskCapacity:(NSUInteger)diskCapacity 
+                    diskPath:(NSString *)path
+          enableForIOS5AndUp:(BOOL)enableForIOS5AndUp;
 
 /*
  * Checks if the provided URL exists in cache.

--- a/SDURLCache.m
+++ b/SDURLCache.m
@@ -426,7 +426,7 @@ static NSDateFormatter* CreateDateFormatter(NSString *format)
     // iOS 5 implements disk caching. SDURLCache then disables itself at runtime if the current device OS
     // version is 5 or greater
     NSArray *version = [[UIDevice currentDevice].systemVersion componentsSeparatedByString:@"."];
-    disabled = [[version objectAtIndex:0] intValue] >= 5;
+    disabled = [[version objectAtIndex:0] intValue] >= 5 && !_enableForIOS5AndUp;
 
     if (disabled)
     {
@@ -450,6 +450,18 @@ static NSDateFormatter* CreateDateFormatter(NSString *format)
 
     return self;
 }
+
+- (id)initWithMemoryCapacity:(NSUInteger)memoryCapacity 
+                diskCapacity:(NSUInteger)diskCapacity 
+                    diskPath:(NSString *)path
+          enableForIOS5AndUp:(BOOL)enableForIOS5AndUp {
+    
+    _enableForIOS5AndUp = enableForIOS5AndUp;
+    return [self initWithMemoryCapacity:memoryCapacity
+                           diskCapacity:diskCapacity
+                               diskPath:path];
+}
+
 
 - (void)storeCachedResponse:(NSCachedURLResponse *)cachedResponse forRequest:(NSURLRequest *)request
 {


### PR DESCRIPTION
 It turns that although ios > 5 has a disk cache it doesn't behave in a predicatable way the added enableForIOS5AndUp will enable SDURLCache to function like it does on all version of IOS
